### PR TITLE
add monitoring scripts to base images

### DIFF
--- a/playbooks/roles/base_buri/files/CloudWatchClient.pm
+++ b/playbooks/roles/base_buri/files/CloudWatchClient.pm
@@ -1,0 +1,649 @@
+# Copyright 2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not 
+# use this file except in compliance with the License. A copy of the License 
+# is located at
+#
+#        http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE" file accompanying this file. This file is distributed 
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
+# express or implied. See the License for the specific language governing 
+# permissions and limitations under the License.
+
+package CloudWatchClient;
+
+use strict;
+use warnings;
+use base 'Exporter';
+our @EXPORT = qw();
+use Switch;
+use Digest::SHA qw(hmac_sha256_base64);
+use URI::Escape qw(uri_escape_utf8);
+use Compress::Zlib;
+use File::Basename;
+use LWP;
+
+use LWP::Simple qw($ua get);
+$ua->timeout(2); # timeout for meta-data calls
+
+our $client_version = '1.1.0';
+our $service_version = '2010-08-01';
+our $compress_threshold_bytes = 2048;
+our $meta_data_ttl = 21600; # 6 hours
+our $max_meta_data_ttl = 86400; # 1 day
+our $http_request_timeout = 5; # seconds
+
+# RFC3986 unsafe characters
+our $unsafe_characters = "^A-Za-z0-9\-\._~";
+
+our $region;
+our $avail_zone;
+our $instance_id;
+our $image_id;
+our $instance_type;
+our $as_group_name; 	 
+our $meta_data_loc = '/var/tmp/aws-mon';
+
+#
+# Queries meta data for the current EC2 instance.
+#
+sub get_meta_data
+{
+  my $resource = shift;
+  my $use_cache = shift;
+  my $data_value = read_meta_data($resource, $meta_data_ttl);
+  
+  if (!defined($data_value) || length($data_value) == 0) {
+    my $base_uri = 'http://169.254.169.254/latest/meta-data';
+    $data_value = get $base_uri.$resource;
+    if ($use_cache) {
+      write_meta_data($resource, $data_value);
+    }
+  }
+  
+  return $data_value;
+}
+
+#
+# Reads meta-data from the local filesystem.
+#
+sub read_meta_data
+{
+  my $resource = shift;
+  my $default_ttl = shift;
+  
+  my $location = $ENV{'AWS_EC2CW_META_DATA'};
+  if (!defined($location) || length($location) == 0) { 	 
+    $location = $meta_data_loc if ($meta_data_loc); 	 
+  }
+  my $meta_data_ttl = $ENV{'AWS_EC2CW_META_DATA_TTL'};
+  $meta_data_ttl = $default_ttl if (!defined($meta_data_ttl));
+  
+  my $data_value;
+  if ($location)
+  {
+    my $filename = $location.$resource;
+    if (-d $filename) {
+      $data_value = `/bin/ls $filename`;
+      chomp($data_value);
+    } elsif (-e $filename) {
+      my $updated = (stat($filename))[9];
+      my $file_age = time() - $updated;
+      if ($file_age < $meta_data_ttl)
+      {
+        open MDATA, "$filename";
+        while(my $line = <MDATA>) {
+          $data_value .= $line;
+        }
+        close MDATA;
+        chomp $data_value;
+      }
+    }
+  }
+  
+  return $data_value;
+}
+
+#
+# Writes meta-data to the local filesystem. 	 
+# 	 
+sub write_meta_data 	 
+{ 	 
+  my $resource = shift; 	 
+  my $data_value = shift; 	 
+   
+  if ($resource && $data_value) 	 
+  { 	 
+    my $location = $ENV{'AWS_EC2CW_META_DATA'}; 	 
+    if (!defined($location) || length($location) == 0) { 	 
+      $location = $meta_data_loc if ($meta_data_loc); 	 
+    } 	 
+
+    if ($location) 	 
+    { 	 
+      my $filename = $location.$resource; 	 
+      my $directory = dirname($filename); 	 
+      `/bin/mkdir -p $directory` unless -d $directory; 	 
+
+      open MDATA, ">$filename"; 	 
+      print MDATA $data_value; 	 
+      close MDATA; 	 
+    } 	 
+  } 	 
+}
+
+#
+# Builds up ec2 endpoint URL for this region.
+#
+sub get_ec2_endpoint
+{
+  my $region = get_region();
+  
+  if ($region) {
+    return "https://ec2.$region.amazonaws.com/"; 
+  }
+  
+  return 'https://ec2.amazonaws.com/';
+}
+
+#
+# Obtains Auto Scaling group name by making EC2 API call.
+#
+sub get_auto_scaling_group
+{
+  if ($as_group_name) {
+    return (200, $as_group_name);
+  }
+
+  # Try getting AS group name from the local cache and avoid calling EC2 API for
+  # at least several hours. AS group name is not something that changes at all
+  # but just in case if it changes at some point, read the value from the tag.
+  
+  my $resource = '/as-group-name';
+  $as_group_name = read_meta_data($resource, $meta_data_ttl);
+  if ($as_group_name) {
+    return (200, $as_group_name);
+  }
+
+  my $opts = shift;
+  
+  my %ec2_opts = ();
+  $ec2_opts{'aws-credential-file'} = $opts->{'aws-credential-file'};
+  $ec2_opts{'aws-access-key-id'} = $opts->{'aws-access-key-id'};
+  $ec2_opts{'aws-secret-key'} = $opts->{'aws-secret-key'};
+  $ec2_opts{'short-response'} = 0;
+  $ec2_opts{'retries'} = 1;
+  $ec2_opts{'verbose'} = $opts->{'verbose'};
+  $ec2_opts{'verify'} = $opts->{'verify'};
+  $ec2_opts{'user-agent'} = $opts->{'user-agent'};
+  $ec2_opts{'version'} = '2011-12-15';
+  $ec2_opts{'url'} = get_ec2_endpoint();
+  $ec2_opts{'aws-iam-role'} = $opts->{'aws-iam-role'};
+  
+  my %ec2_params = ();
+  $ec2_params{'Action'} = 'DescribeTags';
+  $ec2_params{'Filter.1.Name'} = 'resource-id';
+  $ec2_params{'Filter.1.Value.1'} = get_instance_id();
+  $ec2_params{'Filter.2.Name'} = 'key';
+  $ec2_params{'Filter.2.Value.1'} = 'aws:autoscaling:groupName';
+  
+  my ($code, $reply) = call(\%ec2_params, \%ec2_opts);
+  
+  if ($code == 200)
+  {
+    my $pattern = "<value>(.*?)<\/value>";
+    $reply =~ /$pattern/s;
+    if ($1) {
+      $reply = $1;
+      write_meta_data($resource, $reply);
+    }
+    else {
+      undef $reply;
+    }
+  }
+  else
+  {
+    my $pattern = "<Message>(.*?)<\/Message>";
+    $reply =~ /$pattern/s;
+    $reply = $1 if ($1);
+  }
+  
+  # In case when EC2 API call fails for whatever reason, keep using the older
+  # value if it is present. Only ofter one day, assume this value is obsolete.
+  # AS group name is not something that is changing on the fly anyway.
+  
+  if (!$as_group_name)
+  {
+    # EC2 call failed, so try using older value for AS group name
+    $as_group_name = read_meta_data($resource, $max_meta_data_ttl);
+    if ($as_group_name) {
+      return (200, $as_group_name);
+    }
+  }
+
+  return ($code, $reply);
+}
+
+#
+# Obtains EC2 instance id from meta data.
+#
+sub get_instance_id
+{
+  if (!$instance_id) {
+    $instance_id = get_meta_data('/instance-id', 1);
+  }
+  return $instance_id;
+}
+
+#
+# Obtains EC2 instance type from meta data.
+#
+sub get_instance_type
+{
+  if (!$instance_type) {
+    $instance_type = get_meta_data('/instance-type', 1);
+  }
+  return $instance_type;
+}
+
+#
+# Obtains EC2 image id from meta data.
+#
+sub get_image_id
+{
+  if (!$image_id) {
+    $image_id = get_meta_data('/ami-id', 1);
+  }
+  return $image_id;
+}
+
+#
+# Obtains EC2 avilability zone from meta data.
+#
+sub get_avail_zone
+{
+  if (!$avail_zone) {
+    $avail_zone = get_meta_data('/placement/availability-zone', 1);
+  }
+  return $avail_zone;
+}
+
+#
+# Extracts region from avilability zone.
+#
+sub get_region
+{
+  if (!$region) {
+    my $azone = get_avail_zone();
+    if ($azone) {
+      $region = substr($azone, 0, -1);
+    }
+  }
+  return $region;
+}
+
+#
+# Buids up the endpoint based on the provided region.
+#
+sub get_endpoint
+{
+  my $region = get_region();
+  
+  if ($region) {
+    return "https://monitoring.$region.amazonaws.com/";
+  }
+  
+  return 'https://monitoring.amazonaws.com/';
+}
+
+#
+# Read credentials from the IAM Role Metadata.
+#
+sub prepare_iam_role
+{
+  my $opts = shift;
+  my $verbose = $opts->{'verbose'};
+  my $outfile = $opts->{'output-file'};
+  my $iam_role = $opts->{'aws-iam-role'};
+  my $iam_dir = "/iam/security-credentials/";
+
+  # if am_role is not explicitly specified 
+  if (!defined($iam_role)) {
+    my $roles = get_meta_data($iam_dir, 0);
+    my $nr_of_roles = $roles =~ tr/\n//;
+
+    print_out("No credential methods are specified. Trying default IAM role.", $outfile) if $verbose;
+    if ($roles eq "") {
+      return(0, "No IAM role is associated with this EC2 instance.");
+    } elsif ($nr_of_roles == 0) {
+      # if only one role
+      $iam_role = $roles;
+    } else {
+      $roles =~ s/\n/, /g; # puts all the roles on one line 
+      $roles =~ s/, $// ; # deletes the comma at the end
+      return(0, "More than one IAM roles are associated with this EC2 instance: $roles.");
+    }
+  }
+  my $role_content = get_meta_data(($iam_dir.$iam_role), 0);
+
+  # Could not find the IAM role metadata
+  if(!$role_content) {
+    my $roles = get_meta_data($iam_dir, 0);
+    my $roles_message;
+    if($roles) {
+      $roles =~ s/\n/, /g; # puts all the roles on one line
+      $roles =~ s/, $// ; # deletes the comma at the end
+      $roles_message = "Available roles: " . $roles;
+    } else {
+      $roles_message = "This EC2 instance does not have an IAM role associated with it.";
+    }
+    return(0, "Failed to obtain credentials for IAM role $iam_role. $roles_message");
+  }
+
+  print_out("Using IAM role <$iam_role>", $outfile) if $verbose;
+  my $id;
+  my $key;
+  my $token;
+  while ($role_content =~ /(.*)\n/g ) {
+    
+    my $line = $1;
+    if ( $line =~ /"AccessKeyId"[ \t]*:[ \t]*"(.+)"/) {
+      $id = $1;
+      next;
+    }
+  
+    if ( $line =~ /"SecretAccessKey"[ \t]*:[ \t]*"(.+)"/) {
+      $key = $1;
+      next;
+    }
+    
+    if ( $line =~ /"Token"[ \t]*:[ \t]*"(.+)"/) {
+      $token = $1;
+      next;
+    }
+    
+  }
+
+  my $role_statement = "from IAM role <$iam_role>";
+  if (!defined($id) && !defined($key)) {
+    return(0, "Failed to parse AWS access key id and secret key $role_statement.");
+  } elsif (!defined($id)) {
+    return(0, "Failed to parse AWS access key id $role_statement.");
+  } elsif (!defined($key)) {
+    return(0, "Failed to parse AWS secret key $role_statement.");
+  }
+  
+  $opts->{'aws-access-key-id'} = $id;
+  $opts->{'aws-secret-key'} = $key;
+  $opts->{'aws-security-token'} = $token;
+  return(1,'');
+}
+
+#
+# Checks if credential set is present. If not, reads credentials from file.
+#
+sub prepare_credentials
+{
+  my $opts = shift;
+  my $verbose = $opts->{'verbose'};
+  my $outfile = $opts->{'output-file'};
+  my $aws_access_key_id = $opts->{'aws-access-key-id'};
+  my $aws_secret_key = $opts->{'aws-secret-key'};
+  my $aws_credential_file = $opts->{'aws-credential-file'};
+  
+  if (defined($aws_access_key_id) && !$aws_access_key_id) {
+    return(0, 'Provided empty AWS access key id.');
+  }
+  if (defined($aws_secret_key) && !$aws_secret_key) {
+    return(0, 'Provided empty AWS secret key.');
+  }  
+  if ($aws_access_key_id && $aws_secret_key) {
+    return(1, '');
+  }
+  
+  if (!defined($aws_credential_file) || length($aws_credential_file) == 0) {
+    my $env_creds_file = $ENV{'AWS_CREDENTIAL_FILE'};
+    if (defined($env_creds_file) && length($env_creds_file) > 0) {
+      $aws_credential_file = $env_creds_file;
+    }
+  }
+  
+  if ($aws_credential_file)
+  {
+    my $file = $aws_credential_file;
+    open(FILE, '<:utf8', $file) or return(0, "Failed to open AWS credentials file <$file>");
+    print_out("Using AWS credentials file <$aws_credential_file>", $outfile) if $verbose;
+    
+    while (my $line = <FILE>)
+    {
+      $line =~ /^$/ and next; # skip empty lines
+      $line =~ /^#.*/ and next; # skip commented lines
+      $line =~ /^\s*(.*?)=(.*?)\s*$/ or return(0, "Failed to parse AWS credential entry '$line' in <$file>.");
+      my ($key, $value) = ($1, $2);
+      switch ($key)
+      {
+        case 'AWSAccessKeyId' { $aws_access_key_id = $value; }
+        case 'AWSSecretKey'   { $aws_secret_key = $value; }
+      }
+    }
+    close (FILE);
+
+    $opts->{'aws-access-key-id'} = $aws_access_key_id;
+    $opts->{'aws-secret-key'} = $aws_secret_key;
+  }
+  
+  if (!$aws_access_key_id || !$aws_secret_key) {
+    # if all the credential methods failed, try iam_role
+    # either the default or user specified IAM role
+    return prepare_iam_role($opts);
+  }
+  
+  return (1, '');
+}
+
+#
+# Returns UTC time in required format.
+#
+sub get_timestamp
+{
+  my $time = shift;
+  sprintf("%04d-%02d-%02dT%02d:%02d:%02d.000Z",
+    sub {($_[5]+1900,$_[4]+1,$_[3],$_[2],$_[1],$_[0])}->(gmtime($time)));
+}
+
+#
+# Prints out diagnostic message to a file or standard output.
+#
+sub print_out
+{
+  my $text = shift;
+  my $filename = shift;
+  
+  if ($filename)
+  {
+    open OUT_STREAM, ">>$filename";
+    print OUT_STREAM "$text\n";
+    close OUT_STREAM;
+  }
+  else
+  {
+    print "$text\n";
+  }
+}
+
+#
+# Builds the service invocation payload including the signature.
+#
+sub build_payload
+{
+  my $params = shift;
+  my $opts = shift;
+  
+  $params->{'AWSAccessKeyId'} = $opts->{'aws-access-key-id'};
+  $params->{'Timestamp'} = get_timestamp(time());
+  $params->{'SignatureMethod'}  = 'HmacSHA256';
+  $params->{'SignatureVersion'} = '2';
+  
+  # if working with an IAM role, include the Security Token
+  if($opts->{'aws-security-token'}) {
+    $params->{'SecurityToken'} = $opts->{'aws-security-token'};
+  }
+  
+  my $endpoint = $opts->{'url'};
+  my $endpoint_name = $endpoint;
+  if ( !($endpoint_name =~ s!^https?://(.*?)/?$!$1!) ) {
+    return (0, "Invalid AWS endpoint URL <$endpoint>");
+  }
+
+  my $sign_data = '';
+  $sign_data .= 'POST';
+  $sign_data .= "\n";
+  $sign_data .= $endpoint_name;
+  $sign_data .= "\n";
+  $sign_data .= '/';
+  $sign_data .= "\n";
+
+  my @args = ();
+  for my $key (sort keys %{$params}) {
+    my $value = $params->{$key};
+    my ($ekey, $evalue) = (uri_escape_utf8($key, $unsafe_characters), 
+      uri_escape_utf8($value, $unsafe_characters));
+    push @args, "$ekey=$evalue";
+  }
+  
+  my $query_string = join '&', @args;
+  $sign_data .= $query_string;
+  
+  my $signature = hmac_sha256_base64($sign_data, $opts->{'aws-secret-key'}).'=';
+  my $payload = $query_string.'&Signature='.uri_escape_utf8($signature);
+  
+  return (1, $payload);
+}
+
+#
+# Makes a remote invocation to CloudWatch service.
+#
+sub call
+{
+  my $params = shift;
+  my $opts = shift;
+  
+  my $endpoint;
+  if (defined($opts->{'url'})) {
+    $endpoint = $opts->{'url'};
+  }
+  else {
+    $endpoint = get_endpoint();
+    $opts->{'url'} = $endpoint;
+  }
+  
+  if (!defined($opts->{'version'})) {
+    $opts->{'version'} = $service_version;
+  }
+  $params->{'Version'} = $opts->{'version'};
+  
+  my $user_agent_string = "CloudWatch-Scripting/$client_version";
+  if (defined($opts->{'user-agent'})) {
+    $user_agent_string = $opts->{'user-agent'};
+  }
+
+  my $res_code;
+  my $res_msg;
+  my $payload;
+  
+  ($res_code, $res_msg) = prepare_credentials($opts);
+  
+  if ($res_code == 0) {
+    return ($res_code, $res_msg);
+  }
+  
+  ($res_code, $payload) = build_payload($params, $opts);
+  
+  if ($res_code == 0) {
+    return ($res_code, $payload);
+  }
+  
+  my $user_agent = new LWP::UserAgent(agent => $user_agent_string);
+  $user_agent->timeout($http_request_timeout);
+  my $request = new HTTP::Request 'POST', $endpoint;
+  
+  $request->content_type('application/x-www-form-urlencoded');
+  $request->content($payload);
+  
+  if (defined($opts->{'enable-compression'}) && length($payload) > $compress_threshold_bytes) {
+    $request->encode('gzip');
+  }
+  
+  my $response;
+  my $keep_trying = 1;
+  my $call_attempts = 1;
+  my $verbose = $opts->{'verbose'};
+  my $outfile = $opts->{'output-file'};
+  
+  print_out("Endpoint: $endpoint", $outfile) if $verbose;
+  print_out("Payload: $payload", $outfile) if $verbose;
+  
+  # initial and max delay in seconds between retries
+  my $delay = 4; 
+  my $max_delay = 16;
+  
+  if (defined($opts->{'retries'})) {
+    $call_attempts += $opts->{'retries'};
+  }  
+  if (defined($opts->{'max-backoff-sec'})) {
+    $max_delay = $opts->{'max-backoff-sec'};
+  }
+
+  my $response_code = 0;
+  
+  if ($opts->{'verify'}) {
+    return (200, 'This is a verification run, not an actual response.');
+  }
+  
+  for (my $i = 0; $i < $call_attempts && $keep_trying; ++$i)
+  {
+    my $attempt = $i + 1;
+    $response = $user_agent->request($request);
+    $response_code = $response->code;
+    if ($verbose) {
+      print_out("Received HTTP status $response_code on attempt $attempt", $outfile);
+      if ($response_code != 200) {
+        print_out($response->content, $outfile);
+      }
+    }
+    $keep_trying = 0;
+    if ($response_code >= 500) {
+      $keep_trying = 1;
+    } elsif ($response_code == 400) {
+      # special case to handle throttling fault
+      my $pattern = "<Code>Throttling<\/Code>";
+      if ($response->content =~ m/$pattern/) {
+        print_out("Request throttled.", $outfile) if $verbose;
+        $keep_trying = 1;
+      }
+    }
+    if ($keep_trying && $attempt < $call_attempts) {
+      print_out("Waiting $delay seconds before next retry.", $outfile) if $verbose;
+      sleep($delay);
+      my $incdelay = $delay * 2;
+      $delay = $incdelay > $max_delay ? $max_delay : $incdelay;
+    }
+  }
+  
+  my $response_content = $response->content;
+  print_out($response_content, $outfile) if ($verbose && $response_code == 200);
+
+  if ($opts->{'short-response'}) {
+    my $pattern = $response->is_success ?
+      "<RequestId>(.*?)<\/RequestId>" : "<Message>(.*?)<\/Message>";
+    $response_content =~ /$pattern/s;
+    if ($1) {
+      $response_content = $1;
+    }
+  }
+
+  return ($response->code, $response_content);
+}
+
+1;

--- a/playbooks/roles/base_buri/files/mon-put-instance-data.pl
+++ b/playbooks/roles/base_buri/files/mon-put-instance-data.pl
@@ -1,0 +1,601 @@
+#!/usr/bin/perl -w
+
+# Copyright 2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not 
+# use this file except in compliance with the License. A copy of the License 
+# is located at
+#
+#        http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE" file accompanying this file. This file is distributed 
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
+# express or implied. See the License for the specific language governing 
+# permissions and limitations under the License.
+
+our $usage = <<USAGE;
+
+Usage: mon-put-instance-data.pl [options]
+
+  Collects memory, swap, and disk space utilization on an Amazon EC2
+  instance and sends this data as custom metrics to Amazon CloudWatch.
+
+Description of available options:
+
+  --mem-util          Reports memory utilization in percentages.
+  --mem-used          Reports memory used in megabytes.
+  --mem-avail         Reports available memory in megabytes.
+  --swap-util         Reports swap utilization in percentages.
+  --swap-used         Reports allocated swap space in megabytes.
+  --disk-path=PATH    Selects the disk by the path on which to report.
+  --disk-space-util   Reports disk space utilization in percentages.  
+  --disk-space-used   Reports allocated disk space in gigabytes.
+  --disk-space-avail  Reports available disk space in gigabytes.
+  
+  --aggregated[=only]    Adds aggregated metrics for instance type, AMI id, and overall.
+  --auto-scaling[=only]  Adds aggregated metrics for Auto Scaling group.
+                         If =only is specified, reports only aggregated metrics.
+
+  --mem-used-incl-cache-buff  Count memory that is cached and in buffers as used.
+  --memory-units=UNITS        Specifies units for memory metrics.
+  --disk-space-units=UNITS    Specifies units for disk space metrics.
+  
+    Supported UNITS are bytes, kilobytes, megabytes, and gigabytes.
+
+  --aws-credential-file=PATH  Specifies the location of the file with AWS credentials.
+  --aws-access-key-id=VALUE   Specifies the AWS access key ID to use to identify the caller.
+  --aws-secret-key=VALUE      Specifies the AWS secret key to use to sign the request.
+  --aws-iam-role=VALUE        Specifies the IAM role name to provide AWS credentials.
+
+  --from-cron  Specifies that this script is running from cron.
+  --verify     Checks configuration and prepares a remote call.
+  --verbose    Displays details of what the script is doing.
+  --version    Displays the version number.
+  --help       Displays detailed usage information.
+  
+Examples
+ 
+ To perform a simple test run without posting data to Amazon CloudWatch
+ 
+  ./mon-put-instance-data.pl --mem-util --verify --verbose
+ 
+ To set a five-minute cron schedule to report memory and disk space utilization to CloudWatch
+  
+  */5 * * * * ~/aws-scripts-mon/mon-put-instance-data.pl --mem-util --disk-space-util --disk-path=/ --from-cron
+
+For more information on how to use this utility, see Amazon CloudWatch Developer Guide at
+http://docs.amazonwebservices.com/AmazonCloudWatch/latest/DeveloperGuide/mon-scripts-perl.html
+
+USAGE
+
+use strict;
+use warnings;
+use Switch;
+use Getopt::Long;
+use File::Basename;
+use Sys::Hostname;
+use Sys::Syslog qw(:DEFAULT setlogsock);
+use Sys::Syslog qw(:standard :macros);
+
+BEGIN
+{
+  my $script_dir = &File::Basename::dirname($0);
+  push @INC, $script_dir;
+}
+
+use CloudWatchClient;
+
+use constant
+{
+  KILO => 1024,
+  MEGA => 1048576,
+  GIGA => 1073741824,
+};
+
+my $version = '1.1.0';
+my $client_name = 'CloudWatch-PutInstanceData';
+
+my $mcount = 0;
+my $report_mem_util;
+my $report_mem_used;
+my $report_mem_avail;
+my $report_swap_util;
+my $report_swap_used;
+my $report_disk_util;
+my $report_disk_used;
+my $report_disk_avail;
+my $mem_used_incl_cache_buff;
+my @mount_path;
+my $mem_units;
+my $disk_units;
+my $mem_unit_div = 1;
+my $disk_unit_div = 1;
+my $aggregated; 	 
+my $auto_scaling; 	 
+my $from_cron;
+my $verify;
+my $verbose;
+my $show_help;
+my $show_version;
+my $enable_compression;
+my $aws_credential_file;
+my $aws_access_key_id;
+my $aws_secret_key;
+my $aws_iam_role;
+my $parse_result = 1;
+my $parse_error = '';
+my $argv_size = @ARGV;
+
+{
+  # Capture warnings from GetOptions
+  local $SIG{__WARN__} = sub { $parse_error .= $_[0]; };
+
+  $parse_result = GetOptions(
+    'help|?' => \$show_help,
+    'version' => \$show_version,
+    'mem-util' => \$report_mem_util,
+    'mem-used' => \$report_mem_used,
+    'mem-avail' => \$report_mem_avail,
+    'swap-util' => \$report_swap_util,
+    'swap-used' => \$report_swap_used,
+    'disk-path:s' => \@mount_path,
+    'disk-space-util' => \$report_disk_util,
+    'disk-space-used' => \$report_disk_used,
+    'disk-space-avail' => \$report_disk_avail,
+    'auto-scaling:s' => \$auto_scaling,
+    'aggregated:s' => \$aggregated,
+    'memory-units:s' => \$mem_units,
+    'disk-space-units:s' => \$disk_units,
+    'mem-used-incl-cache-buff' => \$mem_used_incl_cache_buff,
+    'verify' => \$verify,
+    'from-cron' => \$from_cron,
+    'verbose' => \$verbose,
+    'aws-credential-file:s' => \$aws_credential_file,
+    'aws-access-key-id:s' => \$aws_access_key_id,
+    'aws-secret-key:s' => \$aws_secret_key,
+    'enable-compression' => \$enable_compression,
+    'aws-iam-role:s' => \$aws_iam_role
+    );
+
+}
+
+if (!$parse_result) {
+  exit_with_error($parse_error);
+}
+if ($show_version) {
+  print "\n$client_name version $version\n\n";
+  exit 0;
+}
+if ($show_help || $argv_size < 1) {
+  print $usage;
+  exit 0;
+}
+if ($from_cron) {
+  $verbose = 0;
+}
+
+# check for empty values in provided arguments
+if (defined($aws_credential_file) && length($aws_credential_file) == 0) {
+  exit_with_error("Path to AWS credential file is not provided.");
+}
+if (defined($aws_access_key_id) && length($aws_access_key_id) == 0) {
+  exit_with_error("Value of AWS access key id is not specified.");
+}
+if (defined($aws_secret_key) && length($aws_secret_key) == 0) {
+  exit_with_error("Value of AWS secret key is not specified.");
+}
+if (defined($mem_units) && length($mem_units) == 0) {
+  exit_with_error("Value of memory units is not specified.");
+}
+if (defined($disk_units) && length($disk_units) == 0) {
+  exit_with_error("Value of disk space units is not specified.");
+}
+if (defined($aws_iam_role) && length($aws_iam_role) == 0) {
+  exit_with_error("Value of AWS IAM role is not specified.");
+}
+
+# check for inconsistency of provided arguments
+if (defined($aws_credential_file) && defined($aws_access_key_id)) {
+  exit_with_error("Do not provide AWS credential file and AWS access key id options together.");
+}
+elsif (defined($aws_credential_file) && defined($aws_secret_key)) {
+  exit_with_error("Do not provide AWS credential file and AWS secret key options together.");
+}
+elsif (defined($aws_access_key_id) && !defined($aws_secret_key)) {
+  exit_with_error("AWS secret key is not specified.");
+}
+elsif (!defined($aws_access_key_id) && defined($aws_secret_key)) {
+  exit_with_error("AWS access key id is not specified.");
+}
+elsif (defined($aws_iam_role) && defined($aws_credential_file)) {
+  exit_with_error("Do not provide AWS IAM role and AWS credential file options together.");
+}
+elsif (defined($aws_iam_role) && defined($aws_secret_key)) {
+  exit_with_error("Do not provide AWS IAM role and AWS access key id/secret key options together.");
+}
+
+# decide on the reporting units for memory and swap usage
+if (!defined($mem_units) || lc($mem_units) eq 'megabytes') {
+  $mem_units = 'Megabytes';
+  $mem_unit_div = MEGA;
+}
+elsif (lc($mem_units) eq 'bytes') {
+  $mem_units = 'Bytes';
+  $mem_unit_div = 1;
+}
+elsif (lc($mem_units) eq 'kilobytes') {
+  $mem_units = 'Kilobytes';
+  $mem_unit_div = KILO;
+}
+elsif (lc($mem_units) eq 'gigabytes') {
+  $mem_units = 'Gigabytes';
+  $mem_unit_div = GIGA;
+}
+else {
+  exit_with_error("Unsupported memory units '$mem_units'. Use Bytes, Kilobytes, Megabytes, or Gigabytes.");
+}
+
+# decide on the reporting units for disk space usage
+if (!defined($disk_units) || lc($disk_units) eq 'gigabytes') {
+  $disk_units = 'Gigabytes';
+  $disk_unit_div = GIGA;
+}
+elsif (lc($disk_units) eq 'bytes') {
+  $disk_units = 'Bytes';
+  $disk_unit_div = 1;
+}
+elsif (lc($disk_units) eq 'kilobytes') {
+  $disk_units = 'Kilobytes';
+  $disk_unit_div = KILO;
+}
+elsif (lc($disk_units) eq 'megabytes') {
+  $disk_units = 'Megabytes';
+  $disk_unit_div = MEGA;
+}
+else {
+  exit_with_error("Unsupported disk space units '$disk_units'. Use Bytes, Kilobytes, Megabytes, or Gigabytes.");
+}
+
+my $df_path = '';
+my $report_disk_space;
+foreach my $path (@mount_path) {
+  if (length($path) == 0) {
+    exit_with_error("Value of disk path is not specified.");
+  }
+  elsif (-e $path) {
+    $report_disk_space = 1;
+    $df_path .= ' '.$path;
+  }
+  else {
+    exit_with_error("Disk file path '$path' does not exist or cannot be accessed.");
+  }
+}
+
+if ($report_disk_space && !$report_disk_util && !$report_disk_used && !$report_disk_avail) {
+  exit_with_error("Disk path is provided but metrics to report disk space are not specified.");
+}
+if (!$report_disk_space && ($report_disk_util || $report_disk_used || $report_disk_avail)) {
+  exit_with_error("Metrics to report disk space are provided but disk path is not specified.");
+}
+
+# check that there is a need to monitor at least something
+if (!$report_mem_util && !$report_mem_used && !$report_mem_avail
+  && !$report_swap_util && !$report_swap_used && !$report_disk_space)
+{
+  exit_with_error("No metrics specified for collection and submission to CloudWatch.");
+}
+
+my $now = time();
+my $timestamp = CloudWatchClient::get_timestamp($now);
+my $instance_id = CloudWatchClient::get_instance_id();
+
+if (!defined($instance_id) || length($instance_id) == 0) {
+  exit_with_error("Cannot obtain instance id from EC2 meta-data.");
+}
+
+if ($aggregated && lc($aggregated) ne 'only') {
+  exit_with_error("Unrecognized value '$aggregated' for --aggregated option.");
+}
+if ($aggregated && lc($aggregated) eq 'only') {
+  $aggregated = 2;
+}
+elsif (defined($aggregated)) {
+  $aggregated = 1;
+}
+
+my $image_id;
+my $instance_type;
+if ($aggregated) {
+  $image_id = CloudWatchClient::get_image_id();
+  $instance_type = CloudWatchClient::get_instance_type();
+}
+
+if ($auto_scaling && lc($auto_scaling) ne 'only') {
+  exit_with_error("Unrecognized value '$auto_scaling' for --auto-scaling option.");
+}
+if ($auto_scaling && lc($auto_scaling) eq 'only') {
+  $auto_scaling = 2;
+}
+elsif (defined($auto_scaling)) {
+  $auto_scaling = 1;
+}
+
+my $as_group_name;
+if ($auto_scaling)
+{
+  my %opts = ();
+  $opts{'aws-credential-file'} = $aws_credential_file;
+  $opts{'aws-access-key-id'} = $aws_access_key_id;
+  $opts{'aws-secret-key'} = $aws_secret_key;
+  $opts{'verbose'} = $verbose;
+  $opts{'verify'} = $verify;
+  $opts{'user-agent'} = "$client_name/$version";
+  $opts{'aws-iam-role'} = $aws_iam_role;
+  
+  my ($code, $reply) = CloudWatchClient::get_auto_scaling_group(\%opts);
+
+  if ($code == 200) {
+    $as_group_name = $reply;
+  }
+  else {
+    report_message(LOG_WARNING, "Failed to call EC2 to obtain Auto Scaling group name. ".
+      "HTTP Status Code: $code. Error Message: $reply");
+  }
+
+  if (!$as_group_name)
+  {
+    if (!$verify)
+    {
+      report_message(LOG_WARNING, "The Auto Scaling metrics will not be reported this time.");
+      
+      if ($auto_scaling == 2) {
+        print("\n") if (!$from_cron);
+        exit 0;
+      }
+    }
+    else {
+      $as_group_name = 'VerificationOnly';
+    }
+  }
+}
+
+my %params = ();
+$params{'Action'} = 'PutMetricData';
+$params{'Namespace'} = 'System/Linux';
+
+# avoid a storm of calls at the beginning of a minute
+if ($from_cron) {
+  sleep(rand(20));
+}
+
+# collect memory and swap metrics
+
+if ($report_mem_util || $report_mem_used || $report_mem_avail || $report_swap_util || $report_swap_used)
+{
+  my %meminfo;
+  foreach my $line (split('\n', `/bin/cat /proc/meminfo`)) {
+    if($line =~ /^(.*?):\s+(\d+)/) {
+      $meminfo{$1} = $2;
+    }
+  }
+
+  # meminfo values are in kilobytes
+  my $mem_total = $meminfo{'MemTotal'} * KILO;
+  my $mem_free = $meminfo{'MemFree'} * KILO;
+  my $mem_cached = $meminfo{'Cached'} * KILO;
+  my $mem_buffers = $meminfo{'Buffers'} * KILO;
+  my $mem_avail = $mem_free;
+  if (!defined($mem_used_incl_cache_buff)) {
+     $mem_avail += $mem_cached + $mem_buffers;
+  }
+  my $mem_used = $mem_total - $mem_avail;
+  my $swap_total = $meminfo{'SwapTotal'} * KILO;
+  my $swap_free = $meminfo{'SwapFree'} * KILO;  
+  my $swap_used = $swap_total - $swap_free;
+  
+  if ($report_mem_util) {
+    my $mem_util = 0;
+    $mem_util = 100 * $mem_used / $mem_total if ($mem_total > 0);
+    add_metric('MemoryUtilization', 'Percent', $mem_util);
+  }
+  if ($report_mem_used) {
+    add_metric('MemoryUsed', $mem_units, $mem_used / $mem_unit_div);
+  }
+  if ($report_mem_avail) {
+    add_metric('MemoryAvailable', $mem_units, $mem_avail / $mem_unit_div);
+  }
+
+  if ($report_swap_util) {
+    my $swap_util = 0;
+    $swap_util = 100 * $swap_used / $swap_total if ($swap_total > 0);
+    add_metric('SwapUtilization', 'Percent', $swap_util);
+  }
+  if ($report_swap_used) {
+    add_metric('SwapUsed', $mem_units, $swap_used / $mem_unit_div);
+  }
+}
+
+# collect disk space metrics
+
+if ($report_disk_space)
+{
+  my @df = `/bin/df -k -l -P $df_path`;
+  shift @df;
+
+  foreach my $line (@df)
+  {
+    my @fields = split('\s+', $line);
+    # Result of df is reported in 1k blocks
+    my $disk_total = $fields[1] * KILO;
+    my $disk_used = $fields[2] * KILO;
+    my $disk_avail = $fields[3] * KILO;
+    my $fsystem = $fields[0];
+    my $mount = $fields[5];
+    
+    if ($report_disk_util) {
+      my $disk_util = 0;
+      $disk_util = 100 * $disk_used / $disk_total if ($disk_total > 0);
+      add_metric('DiskSpaceUtilization', 'Percent', $disk_util, $fsystem, $mount);
+    }
+    if ($report_disk_used) {
+      add_metric('DiskSpaceUsed', $disk_units, $disk_used / $disk_unit_div, $fsystem, $mount);
+    }
+    if ($report_disk_avail) {
+      add_metric('DiskSpaceAvailable', $disk_units, $disk_avail / $disk_unit_div, $fsystem, $mount);
+    }
+  }
+}
+
+# send metrics over to CloudWatch if any
+
+if ($mcount > 0)
+{
+  my %opts = ();
+  $opts{'aws-credential-file'} = $aws_credential_file;
+  $opts{'aws-access-key-id'} = $aws_access_key_id;
+  $opts{'aws-secret-key'} = $aws_secret_key;
+  $opts{'short-response'} = 1;
+  $opts{'retries'} = 2;
+  $opts{'verbose'} = $verbose;
+  $opts{'verify'} = $verify;
+  $opts{'user-agent'} = "$client_name/$version";
+  $opts{'enable_compression'} = 1 if ($enable_compression);
+  $opts{'aws-iam-role'} = $aws_iam_role;
+  
+  my ($code, $reply) = CloudWatchClient::call(\%params, \%opts);
+  
+  if ($code == 200 && !$from_cron) {
+    if ($verify) {
+      print "\nVerification completed successfully. No actual metrics sent to CloudWatch.\n\n";
+    } else {
+      print "\nSuccessfully reported metrics to CloudWatch. Reference Id: $reply\n\n";
+    }
+  }
+  elsif ($code < 100) {
+    exit_with_error("Failed to initialize: $reply");
+  }
+  elsif ($code != 200) {
+    exit_with_error("Failed to call CloudWatch: HTTP $code. Message: $reply");
+  }
+}
+else {
+  exit_with_error("No metrics prepared for submission to CloudWatch.");
+}
+
+exit 0;
+
+#
+# Prints out or logs an error and then exits.
+#
+sub exit_with_error
+{
+  my $message = shift;
+  report_message(LOG_ERR, $message);
+ 
+  if (!$from_cron) {
+    print STDERR "\nFor more information, run 'mon-put-instance-data.pl --help'\n\n";
+  }
+
+  exit 1;
+}
+
+#
+# Prints out or logs a message.
+#
+sub report_message
+{
+  my $log_level = shift;
+  my $message = shift;
+  chomp $message;
+ 
+  if ($from_cron)
+  {
+    setlogsock('unix');
+    openlog($client_name, 'nofatal', LOG_USER);
+    syslog($log_level, $message);
+    closelog;
+  }
+  elsif ($log_level == LOG_ERR) {
+    print STDERR "\nERROR: $message\n";
+  }
+  elsif ($log_level == LOG_WARNING) {
+    print "\nWARNING: $message\n";
+  }
+  elsif ($log_level == LOG_INFO) {
+    print "\nINFO: $message\n";
+  }
+}
+
+#
+# Adds one metric to the CloudWatch request.
+#
+sub add_single_metric
+{
+  my $name = shift;
+  my $unit = shift;
+  my $value = shift;
+  my $mcount = shift;
+  my $dims = shift;
+  my $dcount = 0;
+
+  $params{"MetricData.member.$mcount.MetricName"} = $name;
+  $params{"MetricData.member.$mcount.Timestamp"} = $timestamp;
+  $params{"MetricData.member.$mcount.Value"} = $value;
+  $params{"MetricData.member.$mcount.Unit"} = $unit;
+
+  foreach my $key (sort keys %$dims)
+  {
+    ++$dcount;
+    $params{"MetricData.member.$mcount.Dimensions.member.$dcount.Name"} = $key;
+    $params{"MetricData.member.$mcount.Dimensions.member.$dcount.Value"} = $dims->{$key};
+  }
+}
+
+#
+# Adds a metric and its aggregated clones to the CloudWatch request.
+#
+sub add_metric
+{
+  my $name = shift;
+  my $unit = shift;
+  my $value = shift;
+  my $filesystem = shift;
+  my $mount = shift;
+  my $dcount = 0;
+
+  my %dims = ();
+  my %xdims = ();
+  $xdims{'MountPath'} = $mount if $mount;
+  $xdims{'Filesystem'} = $filesystem if $filesystem;
+
+  my $auto_scaling_only = defined($auto_scaling) && $auto_scaling == 2;
+  my $aggregated_only = defined($aggregated) && $aggregated == 2;
+  
+  if (!$auto_scaling_only && !$aggregated_only) {
+    %dims = (('InstanceId' => $instance_id), %xdims);
+    add_single_metric($name, $unit, $value, ++$mcount, \%dims);
+  }
+  
+  if ($as_group_name) {
+    %dims = (('AutoScalingGroupName' => $as_group_name), %xdims);
+    add_single_metric($name, $unit, $value, ++$mcount, \%dims);
+  }
+
+  if ($instance_type) {
+    %dims = (('InstanceType' => $instance_type), %xdims);
+    add_single_metric($name, $unit, $value, ++$mcount, \%dims);
+  }
+
+  if ($image_id) {
+    %dims = (('ImageId' => $image_id), %xdims);
+    add_single_metric($name, $unit, $value, ++$mcount, \%dims);
+  }
+
+  if ($aggregated) {
+    %dims = %xdims;
+    add_single_metric($name, $unit, $value, ++$mcount, \%dims);
+  }
+
+  print "$name [$mount]: $value ($unit)\n" if ($verbose && $mount);
+  print "$name: $value ($unit)\n" if ($verbose && !$mount);
+}

--- a/playbooks/roles/base_buri/tasks/main.yml
+++ b/playbooks/roles/base_buri/tasks/main.yml
@@ -6,3 +6,5 @@
   when: ansible_distribution == 'Ubuntu'
 - include: install-other.yml
 - include: setup-services.yml
+- include: monitoring-clodwatch.yml
+  when: cloud_target == 'amazon'

--- a/playbooks/roles/base_buri/tasks/monitoring-clodwatch.yml
+++ b/playbooks/roles/base_buri/tasks/monitoring-clodwatch.yml
@@ -1,0 +1,24 @@
+---
+# Install monitoring scripts and cronjobs for cloudwatch instance monitoring
+#
+- name: Install aws cloudwatch monitoring script deps
+  apt: pkg={{ item }} state=latest
+  with_items:
+    - libwww-perl
+    - libswitch-perl
+    - liburi-perl
+
+- name: Copy aws monitoring script
+  copy: src=mon-put-instance-data.pl dest=/usr/bin/ group=root mode=0755
+
+- name: Copy aws monitoring script
+  copy: src=CloudWatchClient.pm dest=/usr/bin/ group=root mode=0755
+
+- name: Add memory monitoring to crontab
+  cron: name="Cloudwatch monitoring [mem]" minute="*/5" job="/usr/bin/mon-put-instance-data.pl --mem-util --from-cron"
+
+- name: Add root monitoring to crontab
+  cron: name="Cloudwatch monitoring [/]" minute="*/5" job="/usr/bin/mon-put-instance-data.pl --disk-space-util --disk-path=/ --from-cron"
+
+- name: Add mnt monitoring to crontab
+  cron: name="Cloudwatch monitoring [/mnt]" minute="*/5" job="/usr/bin/mon-put-instance-data.pl --disk-space-util --disk-path=/mnt --from-cron"


### PR DESCRIPTION
Scripts are from amazon, they require a couple of perl libraries. Also require a policy like this applied to the role the machine is launched with

```
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Allow",
      "Action": [
        "cloudwatch:*",
        "sns:*",
        "autoscaling:Describe*"
      ],
      "Resource": "*"
    }
  ]
}
```
