### PR TITLE
Feature/ansible2.2.2

### DIFF
--- a/buri
+++ b/buri
@@ -88,7 +88,7 @@ def gen_ansible_command(args, playbook, cli_vars):
     if args.vol_type != 'gp2':
         gen_vars += " buri_volume_type='{0}'".format(args.vol_type)
     # commandify
-    cmd = 'ANSIBLE_NOCOWS=1 {0} python -u `which ansible-playbook` {1}/playbooks/{2}.yml -i {3} -e "BURI_BASE=\'{1}\' buri_environment=\'{4}\' {5} {6}{7}" -vvvv'.format(roles_param, args.BURI_BASE, playbook, inventory_path, args.environment, cli_vars, args.extravars, gen_vars)
+    cmd = 'ANSIBLE_NOCOWS=1 {0} python -u `which ansible-playbook` {1}/playbooks/{2}.yml -i {3} -e "BURI_BASE=\'{1}\' buri_environment=\'{4}\' {5} {6}{7}" -vvv'.format(roles_param, args.BURI_BASE, playbook, inventory_path, args.environment, cli_vars, args.extravars, gen_vars)
     return cmd
 
 # Returns an array with as many elements as plays, each element the count of tasks for the play

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -37,5 +37,5 @@ fi
 
 sudo pip install boto
 sudo pip install awscli
-sudo pip install ansible==1.6.10
+sudo pip install ansible=2.2.2
 

--- a/playbooks/create-foundation-ubuntu.yml
+++ b/playbooks/create-foundation-ubuntu.yml
@@ -3,7 +3,8 @@
 - name: Ubuntu Foundation Create
   hosts: localhost
   connection: local
-  sudo: True
+  become: True
+  gather_facts: True
   vars_files:
     - vars/distro/{{ ansible_distribution }}.yml
   vars: 
@@ -29,7 +30,9 @@
     - name: Register chroot target in ansible inventory
       add_host: hostname={{ buri_ami_mount_point }} groups=foundation,chroots
 
+    - debug:
+        var: ansible_distribution_major_version
 - include: _image_prep.yml
-  when: ansible_distribution_major_version > "14"
+  #  when: ansible_distribution_major_version > "14"
 - include: _image_apply_role.yml
 - include: _image_finalize.yml

--- a/playbooks/create-foundation-ubuntu.yml
+++ b/playbooks/create-foundation-ubuntu.yml
@@ -3,7 +3,7 @@
 - name: Ubuntu Foundation Create
   hosts: localhost
   connection: local
-  become: True
+  sudo: True
   gather_facts: True
   vars_files:
     - vars/distro/{{ ansible_distribution }}.yml

--- a/playbooks/roles/base_buri/tasks/monitoring-cloudwatch.yml
+++ b/playbooks/roles/base_buri/tasks/monitoring-cloudwatch.yml
@@ -16,7 +16,7 @@
 
 - name: Create Crontab Entry for Cloudwatch Monitoring
   cron: name="Run aws-scripts-mon"
-        job="/usr/bin/mon-put-instance-data.pl --from-cron --mem-used --mem-avail --swap-used --disk-space-util --auto-scaling $(mount | grep ^/dev/ | awk '{print \"--disk-path=\" $3}' | sed 'N;s/\n/ /')"
+        job="/usr/bin/mon-put-instance-data.pl --from-cron --mem-used --mem-avail --swap-used --disk-space-util --auto-scaling $(mount | grep ^/dev/ | awk '{print \"--disk-path=\" $3}' | sed 'N;s/\\n/ /')"
         user="root"
 
 

--- a/playbooks/roles/oracle-java/meta/main.yml
+++ b/playbooks/roles/oracle-java/meta/main.yml
@@ -1,4 +1,4 @@
 ---
-dependencies:
+#dependencies:
   # Skip foundation run when resnapping base from it
-  - { role: base, when: not image_build }
+  #  - { role: base, when: not image_build }

--- a/playbooks/tasks/buri/detach_failed_vol.yml
+++ b/playbooks/tasks/buri/detach_failed_vol.yml
@@ -7,20 +7,20 @@
   #ignore_errors: yes
 
 - name: Unmount /proc filesystem from chroot
-  command: 'chroot {{ item }} umount /proc'
+  command: 'chroot {{ old_mount.stdout }} umount /proc'
   ignore_errors: yes
-  with_items: old_mount.stdout
+  # with_items: old_mount.stdout
   when: old_mount.stdout != ""
 
 - name: Unmount /dev filesystem from chroot
-  command: 'umount {{ item }}/dev'
+  command: 'umount {{ old_mount.stdout }}/dev'
   ignore_errors: yes
-  with_items: old_mount.stdout
+  # with_items: old_mount.stdout
   when: old_mount.stdout != ""
 
 - name: Unmount EBS volume for chroot
-  command: 'umount {{ item }}'
-  with_items: old_mount.stdout
+  command: 'umount {{ old_mount.stdout }}'
+  # with_items: old_mount.stdout
   when: old_mount.stdout != ""
 
 - name: Discover Volume ID to detatch
@@ -29,8 +29,8 @@
 
 - name: Saving Volume ID as a fact for later use
   set_fact:
-    ebs_volume_id: '{{ item.split("\t")[4] }}'
-  with_items: ebsvol.stdout
+    ebs_volume_id: "{{ ebsvol.stdout.split('\t')[4] }}"
+    # with_items: ebsvol.stdout
 
 - name: Detatch failed working volume
   command: 'aws ec2 detach-volume --region {{ ansible_ec2_placement_region }} --volume-id {{ ebs_volume_id }}'

--- a/playbooks/tasks/ec2/ami/cross_account/common.yml
+++ b/playbooks/tasks/ec2/ami/cross_account/common.yml
@@ -1,5 +1,5 @@
 ---
 - name: Registering cross-account permissions
   command: aws ec2 modify-image-attribute --region us-east-1 --image-id '{{ perm_ami_id }}' --launch-permission "{\"Add\":[{\"UserId\":\"{{ item.value.account }}\"}]}"
-  with_dict: ami_cross_account | default({})
+  with_dict: "{{ ami_cross_account | default({}) }}"
   when: ami_cross_account is defined

--- a/playbooks/tasks/ec2/ami/lookup.yml
+++ b/playbooks/tasks/ec2/ami/lookup.yml
@@ -6,8 +6,7 @@
 
 - name: Saving AKI ID as a fact for later use
   set_fact:
-    ami_aki_id: '{{ item.split("\t")[8] }}'
-  with_items: aki.stdout
+    ami_aki_id: "{{ aki.stdout.split('\t')[8] }}"
 
 # Since PVM is used for legacy only, allow resnapping off HVM AMIs
 # If no AKI is available, simply don't build any PVM AMI
@@ -21,8 +20,7 @@
 
 - name: Saving ebs_parent_id as a fact for later use
   set_fact:
-    ebs_parent_id: '{{ item.split("\t")[3] }}'
-  with_items: ebsparent.stdout
+    ebs_parent_id: "{{ ebsparent.stdout.split('\t')[3] }}"
 
 - name: Find ancestor image name
   shell: 'aws ec2 describe-images --region {{ ansible_ec2_placement_region }} --image-ids {{ buri_ami_ancestor_id }} --output text | grep ^IMAGES'
@@ -30,8 +28,7 @@
 
 - name: Saving buri_ami_ancestor_name value
   set_fact:
-    buri_ami_ancestor_name: '{{ item.split("\t")[8]|default("") }}'
-  with_items: ancestor_name_out.stdout
+    buri_ami_ancestor_name: "{{ ancestor_name_out.stdout.split('\t')[8]|default({}) }}"
 
 - name: Find ancestor image appversion tag
   shell: 'aws ec2 describe-images --region {{ ansible_ec2_placement_region }} --image-ids {{ buri_ami_ancestor_id }} --output text | grep ^TAGS | grep appversion'
@@ -39,8 +36,7 @@
 
 - name: Saving buri_ami_ancestor_appversion value
   set_fact:
-    buri_ami_ancestor_appversion: '{{ item.split("\t")[2]|default("") }}'
-  with_items: ancestor_appversion_out.stdout
+    buri_ami_ancestor_appversion: "{{ ancestor_appversion_out.stdout.split('\t')[2]|default({}) }}"
 
 - name: Find ancestor image base_ami_version tag
   shell: 'aws ec2 describe-images --region {{ ansible_ec2_placement_region }} --image-ids {{ buri_ami_ancestor_id }} --output text | grep ^TAGS | grep base_ami_version'
@@ -48,7 +44,6 @@
 
 - name: Saving buri_ami_ancestor_version value
   set_fact:
-    buri_ami_ancestor_version: '{{ item.split("\t")[2]|default("") }}'
-  with_items: ancestor_base_ami_version_out.stdout
+    buri_ami_ancestor_version: "{{ ancestor_base_ami_version_out.stdout.split('\t')[2]|default({}) }}"
 
 

--- a/playbooks/tasks/ec2/vol/snapshot.yml
+++ b/playbooks/tasks/ec2/vol/snapshot.yml
@@ -6,8 +6,7 @@
 
 - name: Saving Snapshot ID as a fact for later use
   set_fact:
-    ebs_snapshot_id: '{{ item.split("\t")[4] }}'
-  with_items: snap.stdout
+    ebs_snapshot_id: "{{ snap.stdout.split('\t')[4] }}"
 
 - name: Waiting for completion of snapshot
   command: 'aws ec2 describe-snapshots --region {{ ansible_ec2_placement_region }} --snapshot-ids {{ ebs_snapshot_id }} --output text'

--- a/playbooks/tasks/image/Ubuntu/find_aki.yml
+++ b/playbooks/tasks/image/Ubuntu/find_aki.yml
@@ -3,12 +3,11 @@
   set_fact:
     distro_aki_suffix: "{% if ansible_distribution_major_version >= '16' %}-ssd{% else %}{% endif %}"
 
-- name: Find correct AKI ID for PV registration 
+- name: Find correct AKI ID for PV registration
   shell: 'wget -qO- {{ distro_image_query }} | egrep "ebs{{ distro_aki_suffix }}.amd64.{{ ansible_ec2_placement_region }}.*paravirtual"'
   register: aki
 
 - name: Saving AKI ID as a fact for later use
   set_fact:
-    ami_aki_id: '{{ item.split("\t")[8] }}'
-  with_items: aki.stdout
+    ami_aki_id: "{{ aki.stdout.split('\t')[8] }}"
 


### PR DESCRIPTION
This PR adds compatibility with ansible 2.2.2 and preserves 1.6.10 backward compatibility. At some point we may wish to globally change `sudo` to `become`, but I'm leaving it in place for now. 

I've tested foundation, base, cassandra, all-in-one-flux, all-in-one-rss, and cleanup_fail with no issues. There may still be some edge case failures related to quoting and escaping that don't get exercised with the default configurations (see, for example, `base_buri/tasks/monitoring-cloudwatch.yml`), but I'm using this branch in production with Ubuntu 16.04 and ansible 2.2.2.